### PR TITLE
change tooltip: "Language" --> "Primary language"

### DIFF
--- a/main/templates/account/view.html
+++ b/main/templates/account/view.html
@@ -22,7 +22,7 @@
         <h3 title="Followers"><span class="fa fa-fw fa-users"></span> {{account_db.followers_hu}}</h3>
       # endif
       # if account_db.language
-        <h3 title="Language"><span class="fa-fw octicon octicon-file-code"></span> {{account_db.language}}</h3>
+        <h3 title="Primary language"><span class="fa-fw octicon octicon-file-code"></span> {{account_db.language}}</h3>
       # endif
       # if account_db.joined
         <hr>


### PR DESCRIPTION
...to better reflect what this field means. I'm not sure I got it right, though. Could it be referring to the main language of the user's top repository? In any case, the tooltip can be improved IMHO.